### PR TITLE
feat(scalability): adding checks for compression and skipped file

### DIFF
--- a/hardeneks/__init__.py
+++ b/hardeneks/__init__.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from pkg_resources import resource_filename
 import tempfile
-
 import yaml
 
 from botocore.exceptions import EndpointConnectionError

--- a/hardeneks/cluster_wide/scalability/control_plane.py
+++ b/hardeneks/cluster_wide/scalability/control_plane.py
@@ -30,17 +30,21 @@ def check_EKS_version(resources: Resources):
 # if any cluster does not have setting, it returns False
 def check_kubectl_compression(resources: Resources):
     kubeconfig = helpers.get_kube_config()
-    isSetCorrectly = True
+    isSetCorrectly = False
     for cluster in kubeconfig.get("clusters", []):
-        clusterName = cluster.get("name", "NoName")
-        if cluster.get("cluster", {}).get("disable-compression", False) != True:
-            isSetCorrectly = False
-            console.print(
-                Panel(
-                    f"[red]DisableCompression in Cluster {clusterName}  should equal True",
-                    subtitle="[link=https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#disable-kubectl-compression]Click to see the guide[/link]",
+        clusterName = cluster.get("name", None)
+        if (clusterName == resources.cluster):
+            if cluster.get("cluster", {}).get("disable-compression", False) != True:
+                console.print(
+                    Panel(
+                        f"[red]`disable-compression` in Cluster {clusterName}  should equal True",
+                        subtitle="[link=https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#disable-kubectl-compression]Click to see the guide[/link]",
+                    )
                 )
-            )
-            console.print()
+                console.print()
+            else:
+                isSetCorrectly = True
+            break
+        
     
     return isSetCorrectly

--- a/hardeneks/cluster_wide/scalability/control_plane.py
+++ b/hardeneks/cluster_wide/scalability/control_plane.py
@@ -31,8 +31,8 @@ def check_kubectl_compression(resources: Resources):
     kubeconfig = helpers.get_kube_config()
     isSetCorrectly = False
     for cluster in kubeconfig.get("clusters", []):
-        clusterName = cluster.get("name", None)
-        if (clusterName == resources.cluster):
+        clusterName = cluster.get("name", "")
+        if (resources.cluster in clusterName):
             if cluster.get("cluster", {}).get("disable-compression", False) != True:
                 console.print(
                     Panel(

--- a/hardeneks/cluster_wide/scalability/control_plane.py
+++ b/hardeneks/cluster_wide/scalability/control_plane.py
@@ -1,5 +1,4 @@
 import re
-import urllib3
 import kubernetes
 from rich.panel import Panel
 from hardeneks import helpers

--- a/hardeneks/cluster_wide/scalability/control_plane.py
+++ b/hardeneks/cluster_wide/scalability/control_plane.py
@@ -22,3 +22,18 @@ def check_EKS_version(resources: Resources):
         return False
 
     return True
+
+
+def check_kubectl_compression(resources: Resources):
+    _, active_context = kubernetes.config.list_kube_config_contexts()
+    if active_context.get("context", {}).get("disable-compression") != True:
+        console.print(
+            Panel(
+                f"[red]Disable kubectl Compression should equal True",
+                subtitle="[link=https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#disable-kubectl-compression]Click to see the guide[/link]",
+            )
+        )
+        console.print()
+        return False
+    
+    return True

--- a/hardeneks/cluster_wide/scalability/skipped.json
+++ b/hardeneks/cluster_wide/scalability/skipped.json
@@ -1,0 +1,12 @@
+[{
+    "name": "Limit workload and node bursting",
+    "link": "https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#limit-workload-and-node-bursting"
+},
+{
+    "name": "Scale nodes and pods down safely",
+    "link": "https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#scale-nodes-and-pods-down-safely"
+},
+{
+    "name": "Use Client-Side Cache when running Kubectl",
+    "link": "https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#use-client-side-cache-when-running-kubectl"
+}]

--- a/hardeneks/config.yaml
+++ b/hardeneks/config.yaml
@@ -54,6 +54,7 @@ rules:
     scalability:
       control_plane:
         - check_EKS_version
+        - check_kubectl_compression
   namespace_based:
     security: 
       iam:

--- a/hardeneks/helpers.py
+++ b/hardeneks/helpers.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import urllib3
+import yaml
+
+#
+# get_kube_config
+# returns kube config in json
+# 
+# we need to update this function to take in a config string, so users can pass in kubeconfig as a param
+def get_kube_config():
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    # need to fix this, so user can pass in .kube/config as a param (joshkurz)
+    kube_config_orig = f"{Path.home()}/.kube/config"
+
+    with open(kube_config_orig, "r") as fd:
+        kubeconfig = yaml.safe_load(fd)
+    return kubeconfig

--- a/hardeneks/resources.py
+++ b/hardeneks/resources.py
@@ -1,6 +1,5 @@
 from kubernetes import client
 
-
 class Resources:
     def __init__(self, region, context, cluster, namespaces):
         self.region = region

--- a/tests/test_scalability_control_plane.py
+++ b/tests/test_scalability_control_plane.py
@@ -29,17 +29,17 @@ def test_check_EKS_version(mocked_client):
 @patch(helpers.__name__ + ".get_kube_config")
 def test_check_kubectl_compression(mocked_helpers):
     namespaced_resources = Resources(
-        "some_region", "some_context", "some_cluster", []
+        "some_region", "some_context", "foobarcluster", []
     )
     mocked_helpers.return_value = {'clusters': [{'cluster': {'server': 'testtest', 'disable-compression': True}, 'name': 'foobarcluster'}]}
     assert check_kubectl_compression(namespaced_resources)
-    mocked_helpers.return_value = {'clusters': [{'cluster': {'server': 'testtest', 'disable-compression': True}, 'name': 'foobarcluster6'},{'cluster': {'server': 'testtest', 'disable-compression': True}, 'name': 'foobarcluster2'}]}
+    mocked_helpers.return_value = {'clusters': [{'cluster': {'server': 'testtest', 'disable-compression': True}, 'name': 'foobarcluster'}, {'cluster': {'server': 'testtest', 'disable-compression': False}, 'name': 'foobarcluster2'}]}
     assert check_kubectl_compression(namespaced_resources)
-    mocked_helpers.return_value = {'clusters': [{'cluster': {'server': 'testtest', 'disable-compression': True}, 'name': 'foobarcluster3'}, {'cluster': {'server': 'testtest', 'disable-compression': False}, 'name': 'foobarcluster4'}]}
+    mocked_helpers.return_value = {'clusters': [{'cluster': {'server': 'testtest', 'disable-compression': False}, 'name': 'foobarcluster'}, {'cluster': {'server': 'testtest', 'disable-compression': False}, 'name': 'foobarcluster4'}]}
     assert not check_kubectl_compression(namespaced_resources)
     mocked_helpers.return_value = {'clusters': [{'cluster': {'test': 'user'}, 'name': 'foobarcluster7'}]}
     assert not check_kubectl_compression(namespaced_resources)
     mocked_helpers.return_value = {'clusters': [{}]}
     assert not check_kubectl_compression(namespaced_resources)
     mocked_helpers.return_value = {}
-    assert check_kubectl_compression(namespaced_resources)
+    assert not check_kubectl_compression(namespaced_resources)


### PR DESCRIPTION
**Description of changes:** 

* Adding in a check in scalability section from https://aws.github.io/aws-eks-best-practices/scalability/docs/control-plane/#disable-kubectl-compression

* Also adding a skipped.json file. Not sure if this is cool, but trying to keep track of what I am skippig for now, and maybe we could go back and print out what was skipped in each section later if a user wanted to see it. IF anything it's good to keep track of the ones we are skipping over.


I have only tested this by running the tests. I did not compile and run this. Tests are passing before i mocked function and after.
