### PR TITLE
Html output debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Feat
+
+- Add console size as args
+
 ## v0.9.3 (2023-05-15)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ hardeneks [OPTIONS]
 * `--export-html TEXT`: Export the report in html format
 * `--export-json TEXT`: Export the report in json format
 * `--insecure-skip-tls-verify`: Skip TLS verification
+* `--width`: Width of the output (defaults to terminal size)
+* `--height`: Height of the output (defaults to terminal size)
 * `--help`: Show this message and exit.
 
 

--- a/hardeneks/__init__.py
+++ b/hardeneks/__init__.py
@@ -169,6 +169,13 @@ def run_hardeneks(
         False,
         "--insecure-skip-tls-verify",
     ),
+    width: int = typer.Option(
+        default=None, help="Width of the console (defaults to terminal width)"
+    ),
+    height: int = typer.Option(
+        default=None,
+        help="Height of the console (defaults to terminal height)",
+    ),
 ):
     """
     Main entry point to hardeneks.
@@ -183,6 +190,8 @@ def run_hardeneks(
         export-html (str): Export the report in html format
         export-json (str): Export the report in json format
         insecure-skip-tls-verify (str): Skip tls verification
+        width (int): Output width
+        height (int): Output height
 
     Returns:
         None
@@ -193,6 +202,11 @@ def run_hardeneks(
     else:
         # should pass in config file
         kubernetes.config.load_kube_config(context=context)
+
+    if width:
+        console.width = width
+    if height:
+        console.height = height
 
     context = _get_current_context(context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hardeneks"
-version = "0.9.3"
+version = "0.10.0"
 description = ""
 authors = ["Doruk Ozturk <dozturk@amazon.com>"]
 readme = "README.md"
@@ -41,7 +41,7 @@ exclude = '''
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.9.3"
+version = "0.10.0"
 version_files = [
   "pyproject.toml:[tool.commitizen]\nversion",
   "pyproject.toml:[tool.poetry]\nname = \"commitizen\"\nversion",


### PR DESCRIPTION
*Issue #, if available:*
#34 
*Description of changes:*

Added width and height args to the cli. Users can specify the size of the output now by running:
```sh
hardeneks --export-html foo.html --width 600 --height 800
```
By default the size of the terminal will be used
