### PR TITLE
fix: Print namespace name for passed namespace based rules

### DIFF
--- a/hardeneks/namespace_based/reliability/applications.py
+++ b/hardeneks/namespace_based/reliability/applications.py
@@ -16,7 +16,11 @@ class avoid_running_singleton_pods(Rule):
             if not owner:
                 offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod", 
+            namespace=namespaced_resources.namespace
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -41,7 +45,11 @@ class run_multiple_replicas(Rule):
             if deployment.spec.replicas < 2:
                 offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="Deployment")
+        self.result = Result(
+            status=True, 
+            resource_type="Deployment", 
+            namespace=namespaced_resources.namespace
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -73,7 +81,11 @@ class schedule_replicas_across_nodes(Rule):
                 ):
                     offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="Deployment")
+        self.result = Result(
+            status=True, 
+            resource_type="Deployment", 
+            namespace=namespaced_resources.namespace
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -102,7 +114,11 @@ class check_horizontal_pod_autoscaling_exists(Rule):
             if deployment.metadata.name not in hpas:
                 offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="Deployment")
+        self.result = Result(
+            status=True, 
+            resource_type="Deployment",
+            namespace=namespaced_resources.namespace,
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -128,7 +144,11 @@ class check_readiness_probes(Rule):
                 if not container.readiness_probe:
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True,
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -154,7 +174,11 @@ class check_liveness_probes(Rule):
                 if not container.liveness_probe:
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True,
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,

--- a/hardeneks/namespace_based/security/encryption_secrets.py
+++ b/hardeneks/namespace_based/security/encryption_secrets.py
@@ -23,7 +23,11 @@ class disallow_secrets_from_env_vars(Rule):
                         if env_from.secret_ref:
                             offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace
+            )
         if offenders:
             self.result = Result(
                 status=False,

--- a/hardeneks/namespace_based/security/iam.py
+++ b/hardeneks/namespace_based/security/iam.py
@@ -21,7 +21,11 @@ class restrict_wildcard_for_roles(Rule):
                 if "*" in rule.resources:
                     offenders.append(role)
 
-        self.result = Result(status=True, resource_type="Role")
+        self.result = Result(
+            status=True,
+            resource_type="Role",
+            namespace=namespaced_resources.namespace,
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -46,7 +50,11 @@ class disable_service_account_token_mounts(Rule):
             if pod.spec.automount_service_account_token:
                 offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -75,7 +83,11 @@ class disable_run_as_root_user(Rule):
             ):
                 offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -105,7 +117,11 @@ class disable_anonymous_access_for_roles(Rule):
                     ):
                         offenders.append(role_binding)
 
-        self.result = Result(status=True, resource_type="RoleBinding")
+        self.result = Result(
+            status=True,
+            resource_type="RoleBinding",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -141,7 +157,11 @@ class use_dedicated_service_accounts_for_each_deployment(Rule):
                 if k == deployment.spec.template.spec.service_account_name:
                     offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="Deployment")
+        self.result = Result(
+            status=True,
+            resource_type="Deployment",
+            namespace=namespaced_resources.namespace,
+        )
         if offenders:
             self.result = Result(
                 status=False,
@@ -179,7 +199,11 @@ class use_dedicated_service_accounts_for_each_stateful_set(
                 if k == deployment.spec.template.spec.service_account_name:
                     offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="StatefulSet")
+        self.result = Result(
+            status=True,
+            resource_type="StatefulSet",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -217,7 +241,11 @@ class use_dedicated_service_accounts_for_each_daemon_set(
                 if k == deployment.spec.template.spec.service_account_name:
                     offenders.append(deployment)
 
-        self.result = Result(status=True, resource_type="DaemonSet")
+        self.result = Result(
+            status=True, 
+            resource_type="DaemonSet",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,

--- a/hardeneks/namespace_based/security/network_security.py
+++ b/hardeneks/namespace_based/security/network_security.py
@@ -24,7 +24,11 @@ class use_encryption_with_aws_load_balancers(Rule):
                 if not (ssl_cert and ssl_cert_port == "443"):
                     offenders.append(service)
 
-        self.result = Result(status=True, resource_type="Service")
+        self.result = Result(
+            status=True, 
+            resource_type="Service",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,

--- a/hardeneks/namespace_based/security/pod_security.py
+++ b/hardeneks/namespace_based/security/pod_security.py
@@ -23,7 +23,11 @@ class disallow_container_socket_mount(Rule):
                 if volume.host_path and volume.host_path.path in sockets:
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -49,7 +53,11 @@ class disallow_host_path_or_make_it_read_only(Rule):
                 if volume.host_path:
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -77,7 +85,11 @@ class set_requests_limits_for_containers(Rule):
                 ):
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -106,7 +118,11 @@ class disallow_privilege_escalation(Rule):
                 ):
                     offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,
@@ -133,7 +149,11 @@ class check_read_only_root_file_system(Rule):
                     and not container.security_context.read_only_root_filesystem
                 ):
                     offenders.append(pod)
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,

--- a/hardeneks/namespace_based/security/runtime_security.py
+++ b/hardeneks/namespace_based/security/runtime_security.py
@@ -39,7 +39,11 @@ class disallow_linux_capabilities(Rule):
                     if not capabilities.issubset(set(allowed_list)):
                         offenders.append(pod)
 
-        self.result = Result(status=True, resource_type="Pod")
+        self.result = Result(
+            status=True, 
+            resource_type="Pod",
+            namespace=namespaced_resources.namespace,
+            )
         if offenders:
             self.result = Result(
                 status=False,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
hardeneks tools show passed namespace based rule as "Cluster Wide". It make confuse user.
This PR makes hardeneks tools to show "namespace name" instead of "Cluster Wide".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
