### PR TITLE
fix: Remove rule type exception and linux capabilities check exception

### DIFF
--- a/hardeneks/__init__.py
+++ b/hardeneks/__init__.py
@@ -239,15 +239,16 @@ def run_hardeneks(
 
     results = []
 
-    cluster_wide_results = harden(resources, rules, "cluster_wide")
+    if "cluster_wide" in rules:
+        cluster_wide_results = harden(resources, rules, "cluster_wide")
+        results = results + cluster_wide_results
 
-    results = results + cluster_wide_results
-
-    for ns in namespaces:
-        resources = NamespacedResources(region, context, cluster, ns)
-        resources.set_resources()
-        namespace_based_results = harden(resources, rules, "namespace_based")
-        results = results + namespace_based_results
+    if "namespace_based" in rules:
+        for ns in namespaces:
+            resources = NamespacedResources(region, context, cluster, ns)
+            resources.set_resources()
+            namespace_based_results = harden(resources, rules, "namespace_based")
+            results = results + namespace_based_results
 
     print_consolidated_results(results)
 

--- a/hardeneks/namespace_based/security/runtime_security.py
+++ b/hardeneks/namespace_based/security/runtime_security.py
@@ -32,6 +32,7 @@ class disallow_linux_capabilities(Rule):
                 if (
                     container.security_context
                     and container.security_context.capabilities
+                    and container.security_context.capabilities.add
                 ):
                     capabilities = set(
                         container.security_context.capabilities.add


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Before call harden() function with rule type, check rules has cluster_wide and namespace_based config. Now hardeneks  is not working with only cluster_wide config or only namespace_based config.
2. Linux capabilities rules checks "container.security_context.capabilities.add" exist before check capability list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
