### PR TITLE
fix: Change validation condition for check_logs_are_enabled rule

### DIFF
--- a/hardeneks/cluster_wide/security/detective_controls.py
+++ b/hardeneks/cluster_wide/security/detective_controls.py
@@ -14,11 +14,10 @@ class check_logs_are_enabled(Rule):
     def check(self, resources: Resources):
         client = boto3.client("eks", region_name=resources.region)
         cluster_metadata = client.describe_cluster(name=resources.cluster)
-        logs = cluster_metadata["cluster"]["logging"]["clusterLogging"][0][
-            "enabled"
-        ]
+        logs = filter(lambda x: x.get('enabled') and 'audit' in x.get('types'),
+                      cluster_metadata["cluster"]["logging"]["clusterLogging"])
         self.result = Result(status=True, resource_type="Log Configuration")
-        if not logs:
+        if not list(logs):
             self.result = Result(
                 status=False, resource_type="Log Configuration"
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is for fixing validation logic for `security/check_logs_are_enabled` rule.
The Validation condition in the rule always return `True` even if the audit log was disabled.
```python
>>> cluster_metadata["cluster"]["logging"]["clusterLogging"]
[{'types': ['api', 'authenticator', 'controllerManager', 'scheduler'], 'enabled': True}, {'types': ['audit'], 'enabled': False}]
>>> cluster_metadata["cluster"]["logging"]["clusterLogging"][0]["enabled"]
True
```

Now changed validation logic correctly.
```python
>>> cluster_metadata["cluster"]["logging"]["clusterLogging"]
[{'types': ['api', 'authenticator', 'controllerManager', 'scheduler'], 'enabled': True}, {'types': ['audit'], 'enabled': False}]
>>> logs = filter(lambda x: x.get('enabled') and 'audit' in x.get('types'), cluster_metadata["cluster"]["logging"]["clusterLogging"])                                                                                                                                                                                     
>>> list(logs)
[]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
