### PR TITLE
Restricts service check for type=LoadBalancer only

### DIFF
--- a/hardeneks/namespace_based/security/network_security.py
+++ b/hardeneks/namespace_based/security/network_security.py
@@ -13,7 +13,7 @@ class use_encryption_with_aws_load_balancers(Rule):
         offenders = []
         for service in namespaced_resources.services:
             annotations = service.metadata.annotations
-            if annotations:
+            if service.spec.type == 'LoadBalancer' and annotations:
                 ssl_cert = (
                     "service.beta.kubernetes.io/aws-load-balancer-ssl-cert"
                     in annotations


### PR DESCRIPTION
Service of type=LoadBalancer are the only where TLS/SSL annotations make sense. This patch avoids false-negatives for services of other ttypes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
