### PR TITLE
add karpenter.sh/nodepool as passing for the use managed node groups check

### DIFF
--- a/hardeneks/cluster_wide/cluster_autoscaling/cluster_autoscaler.py
+++ b/hardeneks/cluster_wide/cluster_autoscaling/cluster_autoscaler.py
@@ -239,6 +239,8 @@ class use_managed_nodegroups(Rule):
                 offenders.append(node)
             elif "karpenter.sh/provisioner-name" in labels.keys():
                 pass
+            elif "karpenter.sh/nodepool" in labels.keys():
+                pass
             else:
                 offenders.append(node)
 


### PR DESCRIPTION
*Description of changes:*
`karpenter.sh/provisioner-name` was [deprecated in v0.33.0](https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-0330) and replaced with `karpenter.sh/nodepool".  This PR adds a check for the new label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.